### PR TITLE
Feature/annotation tracking (#73)

### DIFF
--- a/src/components/annotation-browser/annotation-browser.css
+++ b/src/components/annotation-browser/annotation-browser.css
@@ -29,3 +29,13 @@
 .helpMessage {
   flex: 1
 }
+
+
+.annotation-summary {
+}
+
+.annotation-summary > .title {
+}
+
+.annotation-summary > .body {
+}

--- a/src/components/annotation-browser/annotation-browser.js
+++ b/src/components/annotation-browser/annotation-browser.js
@@ -2,14 +2,15 @@ import React, { useState, useContext, useRef, useEffect, Fragment } from 'react'
 import { Form, Space, Select, Row, Col, InputNumber, Button, Switch, Spin, Alert, notification } from 'antd'
 import { CloudUploadOutlined, ArrowLeftOutlined, QuestionCircleOutlined } from '@ant-design/icons'
 import axios from 'axios'
-import { AnnotationsContext, AnnotationBrowserContext } from '../../contexts'
+import { AnnotationsContext, AnnotationBrowserContext, useAccount } from '../../contexts'
 import { AnnotationPanel } from '../annotation-panel'
+import { AnnotationSummary } from '../annotation-counts'
 import { api } from '../../api'
 import './annotation-browser.css'
-
 const { Option } = Select
 
 export const AnnotationBrowser = () => {
+  const { addSavedImages } = useAccount()
   const [gotImages, setGotImages] = useState(false)
   const [annotationTypes] = useContext(AnnotationsContext)
   const [state, dispatch] = useContext(AnnotationBrowserContext)
@@ -98,7 +99,7 @@ export const AnnotationBrowser = () => {
     dispatch({ type: 'goBack' })
   }
 
-  const onSaveClick = async () => {    
+  const onSaveClick = async () => {
     setSaving(true);
 
     axios.defaults.xsrfHeaderName = 'X-CSRFTOKEN'
@@ -122,10 +123,7 @@ export const AnnotationBrowser = () => {
         })
       })
 
-      dispatch({ 
-        type: 'updateAnnotatedImagesCount', 
-        num: state.images.length
-      }) 
+      addSavedImages(images)
       
       setSaving(false)
 
@@ -249,19 +247,22 @@ export const AnnotationBrowser = () => {
               <>
                 <Form.Item>
                   <Alert message={ 
-                    <div className='helpMessageDiv'>
-                      <div className='helpMessage'>
-                        Select <strong>left</strong>, <strong>front</strong>, and <strong>right</strong> images containing: <strong>{ annotation.name }</strong> <br/>
-                        You have annotated <strong>{ state.annotatedImagesCount }</strong> images during this session
-                      </div> 
-                      <Button
-                        className='iconButton'
-                        type='link'
-                        href='https://docs.google.com/document/d/1-CeqPD1b1cFyMjwYivoBlRXfQp-IuHPBP_sWTLoHHXg/edit?usp=sharing'
-                        icon={ <QuestionCircleOutlined style={{ fontSize: 'large' }} /> }
-                      />
-                    </div>
+                    <Fragment>
+                      <div className='helpMessageDiv'>
+                        <div className='helpMessage'>
+                          Select <strong>left</strong>, <strong>front</strong>, and <strong>right</strong> images containing: <strong>{ annotation.name }</strong> <br/>
+                        </div> 
+                        <Button
+                          className='iconButton'
+                          type='link'
+                          href='https://docs.google.com/document/d/1-CeqPD1b1cFyMjwYivoBlRXfQp-IuHPBP_sWTLoHHXg/edit?usp=sharing'
+                          icon={ <QuestionCircleOutlined style={{ fontSize: 'large' }} /> }
+                        />
+                      </div>
+                    </Fragment>
                   } /> 
+                  <br />
+                  <AnnotationSummary annotationName={ annotation.name }/>
                 </Form.Item>
                 <Form.Item>
                   <SaveButtonGroup isFirst={ true } />

--- a/src/components/annotation-counts/annotation-counts.js
+++ b/src/components/annotation-counts/annotation-counts.js
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
+import { useAccount } from '../../contexts'
+import { Collapse, Space } from 'antd'
+
+const { Panel } = Collapse
+
+export const AnnotationSummary = ({ annotationName }) => {
+  const { savedImages } = useAccount()
+  const [counts, setCounts] = useState({
+    images: 0,
+    annotations: 0,
+    flags: 0,
+  })
+
+  useEffect(() => {
+    const images = savedImages.length
+    const annotations = savedImages.reduce((total, image) => {
+      const hasAnnotation = [image.present.left, image.present.front, image.present.right].includes('present') ? 1 : 0
+      return total + hasAnnotation
+    }, 0)
+    const flags = savedImages.reduce((total, image) => {
+      const hasFlag = [image.present.left, image.present.front, image.present.right].includes('irrelevant') ? 1 : 0
+      return total + hasFlag
+    }, 0)
+    setCounts({
+      ...counts,
+      images: savedImages.length,
+      annotations: annotations,
+      flags: flags,
+    })
+  }, [savedImages])
+
+  return (
+    <Space direction="vertical" style={{ width: '100%' }}>
+      <Collapse collapsible="header">
+        <Panel header="Annotation Summary" key="1">
+          You have saved <strong>{ savedImages.length }</strong> images during this session.<br/>
+          You have annotated <strong>{ counts.annotations }</strong> { annotationName }.<br/>
+          You have flagged <strong>{ counts.flags }</strong> images as irrelevant.
+        </Panel>
+      </Collapse>
+    </Space>
+  )
+}
+
+AnnotationSummary.propTypes = {
+  annotationName: PropTypes.string.isRerquired,
+}

--- a/src/components/annotation-counts/index.js
+++ b/src/components/annotation-counts/index.js
@@ -1,0 +1,1 @@
+export * from './annotation-counts'

--- a/src/components/annotation-panel/annotation-panel.js
+++ b/src/components/annotation-panel/annotation-panel.js
@@ -1,10 +1,11 @@
 import React, { useContext, useState, useRef } from 'react'
-import { AnnotationBrowserContext } from '../../contexts'
+import { AnnotationBrowserContext, useAccount } from '../../contexts'
 import { Scene } from '../scene'
 import { FlagControl } from '../flag-control'
 import './annotation-panel.css'
 
 export const AnnotationPanel = ({ image, autoAdjust, flagOptions, userFlagOptions, flagShortcuts }) => {
+  const {} = useAccount()
   const tooltipTimeout = useRef()
   const [popoverVisible, setPopoverVisible] = useState(false)
   const [tooltip, setTooltip] = useState(null)

--- a/src/contexts/account-context.js
+++ b/src/contexts/account-context.js
@@ -7,6 +7,7 @@ export const useAccount = () => useContext(AccountContext)
 
 export const AccountProvider = ({ children }) => {
   const [account, setAccount] = useState({ })
+  const [savedImages, setSavedImages] = useState([])
 
   useEffect(() => {
     const userId = document.getElementById('user_id').value
@@ -16,9 +17,13 @@ export const AccountProvider = ({ children }) => {
     }
     fetchAccountDetails()
   }, [])
- 
+
   return (
-    <AccountContext.Provider value={{ account: account }}>
+    <AccountContext.Provider value={{
+      account: account,
+      savedImages,
+      addSavedImages: images => setSavedImages(Array.from(new Set([ ...savedImages, ...images ]))),
+    }}>
       { children }
     </AccountContext.Provider>
   )

--- a/src/contexts/annotation-browser-context.js
+++ b/src/contexts/annotation-browser-context.js
@@ -164,12 +164,6 @@ const reducer = (state, action) => {
         autoAdjust: action.autoAdjust
       }
 
-    case 'updateAnnotatedImagesCount':
-      return {
-        ...state,
-        annotatedImagesCount: state.annotatedImagesCount + action.num,
-      }
-
     default: 
       throw new Error('Invalid annotation browser context action: ' + action.type)
   }


### PR DESCRIPTION
* remove annotaiton-counting logic from browser context

* test storeSceneId

* add useLocalStorage hook

* save seen image objects in localStorage

* render saved image couunt in annotation browser

* add annotation summary alert

* render annotation summary in collapsible panel

remove p tag

* pass annotation name to count component

* add prop types

* rename summary component

fix prop types declaration