### PR TITLE
add ability to select base map

### DIFF
--- a/src/components/map/map.css
+++ b/src/components/map/map.css
@@ -1,0 +1,17 @@
+.map {
+  position: relative;
+  overflow: hidden;
+}
+
+.basemap-selector {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  width: 200px;
+  filter: opacity(0.5);
+  transition: filter 250ms;
+}
+
+.map:hover .basemap-selector {
+  filter: opacity(1.0);
+}

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -1,22 +1,50 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { Map as EsriMap } from '@esri/react-arcgis'
+import { Select } from 'antd';
 import { Marker } from './marker'
+import './map.css'
+
+const { Option } = Select
 
 const ncCenter = { lat: 35.393809, long: -79.8431 }
 
-export const Map = ({ height, markers }) => {
+export const Map = ({ height, markers, basemapSelection = true }) => {
+  const [basemap, setBasemap] = useState('gray-vector')
+
+  const handleChangeBasemap = value => {
+    setBasemap(value)
+  }
+
   return (
-    <div className="route-table-map">
+    <div className="map">
+
       <EsriMap
+        key={ basemap}
         style={{ overflow: 'hidden', height: height }}
-        mapProperties={{ basemap: 'gray-vector' }}
+        mapProperties={{ basemap: basemap }}
         viewProperties={{
           center: [ncCenter.long, ncCenter.lat],
           zoom: 7
       }}>
         { markers.length > 0 && markers.map(({ key, ...props }, i) => <Marker key={ `marker-${ i }_-${ props.long },${ props.lat }` } { ...props } />) }
       </EsriMap>
+      {
+        basemapSelection && (
+          <Select className="basemap-selector" defaultValue="gray-vector" onChange={ handleChangeBasemap }>
+            <Option value="dark-gray-vector">Dark Gray Canvas</Option>
+            <Option value="gray-vector">Light Gray Canvas</Option>
+            <Option value="osm">OpenStreetMap</Option>
+            <Option value="satellite">Satellite</Option>
+            <Option value="streets">Streets</Option>
+            <Option value="topo">Topographic Map</Option>
+            <Option value="streets-navigation-vector">World Navigation Map</Option>
+            <Option value="streets-night-vector">World Street Map (Night)</Option>
+            <Option value="streets-relief-vector">World Street Map (with Relief)</Option>
+          </Select>
+        )
+      }
+
     </div>
   )
 }

--- a/src/components/routes-table/expansion-panel.css
+++ b/src/components/routes-table/expansion-panel.css
@@ -25,10 +25,3 @@ tr.ant-table-expanded-row > td.ant-table-cell {
   padding: 0 !important;
 }
 
-.route-table-map {
-  background-color: #ddd;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  border-left: 1px solid #f0f0f0;
-}

--- a/src/components/routes-table/expansion-panel.js
+++ b/src/components/routes-table/expansion-panel.js
@@ -71,7 +71,7 @@ export const ExpansionPanel = ({ data: route }) => {
           </div>
         </Col>
         <Col xs={{ span: 0 }} lg={{ span: 12 }}>
-          <Map markers={ [startingCoordinates, endingCoordinates] } />
+          <Map markers={ [startingCoordinates, endingCoordinates] } basemapSelection={ false } />
         </Col>
       </Row>
     </article>


### PR DESCRIPTION
this adds functionality for the user to select a basemap for the route map component (i selected a few options from https://developers.arcgis.com/javascript/3/jsapi/esri.basemaps-amd.html).

the default is 'gray-vector'.

![Screenshot from 2021-04-30 11-16-06](https://user-images.githubusercontent.com/6019870/116716227-7dc9b080-a9a5-11eb-8478-176907997c66.png)

for developers, there is a Boolean prop, `selectableBasemap`, on the `<Map/>` component to add/remove this functionality.

