### PR TITLE
add zoom functionality to predictions scatterplot

### DIFF
--- a/src/components/route-browser/route-predictions/scatterplot-point.js
+++ b/src/components/route-browser/route-predictions/scatterplot-point.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useState } from 'react'
+import React, { Fragment, useMemo, useState } from 'react'
 import { useRouteContext } from '../context'
 
 export const ScatterplotPoint = ({
@@ -9,15 +9,14 @@ export const ScatterplotPoint = ({
   onClick,
 }) => {
   const { imageIndex, images } = useRouteContext()
-  const [active, setActive] = useState(false)
 
   let fillColor = 'var(--color-neutral)'
   if (node.data?.image?.features[node.data.serieId] && typeof node.data.image.features[node.data.serieId].annotation === 'boolean') {
     fillColor = node.data.image.features[node.data.serieId].annotation ? 'var(--color-positive)' : 'var(--color-negative)'
   }
 
-  useEffect(() => {
-    setActive(node.data.image && +imageIndex === node.data.image.index)
+  const active = useMemo(() => {
+    return node.data.image && +imageIndex === node.data.image.index
   }, [node.data, imageIndex])
 
   return (

--- a/src/components/route-browser/route-predictions/scatterplot-point.js
+++ b/src/components/route-browser/route-predictions/scatterplot-point.js
@@ -18,7 +18,7 @@ export const ScatterplotPoint = ({
 
   useEffect(() => {
     setActive(node.data.image && +imageIndex === node.data.image.index)
-  }, [imageIndex])
+  }, [node.data, imageIndex])
 
   return (
     <Fragment>
@@ -26,7 +26,7 @@ export const ScatterplotPoint = ({
         {
           /* active node indicator */
           active && (
-            <circle className="active-indicator" r={ size } fill={ fillColor } style={{ mixBlendMode: blendMode }}>
+            <circle className="active-indicator" r={ 3 * size } fill="none" stroke="#111" strokeWidth="1" style={{ mixBlendMode: blendMode }}>
               <animate attributeName="r" begin="0s" dur="1s" repeatCount="indefinite" from="3" to="12"/>
               <animate attributeName="opacity" begin="0s" dur="1s" repeatCount="indefinite" from="1" to="0"/>
             </circle>

--- a/src/components/route-browser/route-predictions/scatterplot.css
+++ b/src/components/route-browser/route-predictions/scatterplot.css
@@ -7,7 +7,6 @@
 }
 
 .legend {
-  min-height: 60px;
   display: flex;
   flex-direction: row;
   justify-content: space-around;
@@ -18,7 +17,7 @@
   .legend {
     min-height: 120px;
     flex-direction: column;
-    justify-content: flex-end;
+    justify-content: center;
   }
 }
 

--- a/src/components/route-browser/route-predictions/scatterplot.js
+++ b/src/components/route-browser/route-predictions/scatterplot.js
@@ -108,7 +108,7 @@ const Graph = ({ data, min, max, predictionThreshold }) => {
   )
 }
 
-export const PredictionsScatterplot = ({ key }) => {
+export const PredictionsScatterplot = ({ canZoom }) => {
   const { images, index } = useRouteContext()
   const [predictions, setPredictions] = useState([])
   const [selectedFeature, setSelectedFeature] = useState('guardrail')
@@ -118,7 +118,7 @@ export const PredictionsScatterplot = ({ key }) => {
   const handleZoomSelect = value => setZoom(value)
 
   const extrema = useMemo(() => {
-    if (zoom === 1) {
+    if (zoom === 1 || !canZoom ) {
       return {
         min: 1,
         max: images.length,
@@ -139,7 +139,7 @@ export const PredictionsScatterplot = ({ key }) => {
       min: min,
       max: max,
     }
-  }, [index, zoom])
+  }, [images, index, zoom])
 
   // massage the prediction data into a format usable by this Nivo graph component.
   useEffect(() => {
@@ -180,9 +180,13 @@ export const PredictionsScatterplot = ({ key }) => {
         <Select value={ selectedFeature } onChange={ handleFeatureSelect } style={{ width: '100%' }}>
           { features.map(feature => <Select.Option key={ `feature-option-${ feature }` } value={ feature }>{ feature }</Select.Option>) }
         </Select>
-        <Select value={ zoom } onChange={ handleZoomSelect } style={{ width: '100%' }}>
-          { [1, 2, 3, 4, 5].map(level => <Select.Option key={ `zoom-option-${ level }x` } value={ level }>{ `Zoom ${ level }x` }</Select.Option>) }
-        </Select>
+        {
+          canZoom && (
+            <Select value={ zoom } onChange={ handleZoomSelect } style={{ width: '100%' }}>
+              { [1, 2, 3, 4, 5].map(level => <Select.Option key={ `zoom-option-${ level }x` } value={ level }>{ `Zoom ${ level }x` }</Select.Option>) }
+            </Select>
+          )
+        }
         <Legend />
       </Col>
     </Row>

--- a/src/components/route-browser/route-predictions/scatterplot.js
+++ b/src/components/route-browser/route-predictions/scatterplot.js
@@ -147,6 +147,7 @@ export const PredictionsScatterplot = ({ canZoom }) => {
     setPredictions(data)
   }, [images])
 
+  // set appropriate { min, max } viewing window along horizontal axis
   const extrema = useMemo(() => {
     if (zoom === 1 || !canZoom ) {
       return {

--- a/src/components/route-browser/route-predictions/scatterplot.js
+++ b/src/components/route-browser/route-predictions/scatterplot.js
@@ -75,6 +75,7 @@ const Graph = ({ data, min, max, predictionThreshold }) => {
         xScale={{ type: 'linear', min: min, max: max }}
         yScale={{ type: 'linear', min: -0.05, max: 1.05, stacked: false, reverse: false }}
         yFormat=" >-.2f"
+        animate={ false }
         enableGridX={ true }
         enableGridY={ true }
         axisTop={ null }

--- a/src/components/route-browser/route-predictions/scatterplot.js
+++ b/src/components/route-browser/route-predictions/scatterplot.js
@@ -117,6 +117,36 @@ export const PredictionsScatterplot = ({ canZoom }) => {
   const handleFeatureSelect = value => setSelectedFeature(value)
   const handleZoomSelect = value => setZoom(value)
 
+  useEffect(() => {
+    const fetchThreshold = async () => {
+      try {
+        const { data } = await api.getThreshold(selectedFeature)
+        if (!data) {
+          throw new Error('An error occurred while fetching thresholds.')
+        }
+        setThreshold(data.model_threshold)
+      } catch (error) {
+        console.error(error)
+      }
+    }
+    fetchThreshold(selectedFeature)
+  }, [selectedFeature])
+
+  // massage the prediction data into a format usable by this Nivo graph component.
+  useEffect(() => {
+    const data = { ...initialFeaturePredictions }
+    images.forEach((image, i) => {
+      features.forEach(feature => {
+        if (image.features[feature]) {
+          data[feature].data.push({ x: i + 1, y: image.features[feature].probability, image })
+        }
+        // create dummy nodes?
+        else { data[feature].data.push({ image }) }
+      })
+    })
+    setPredictions(data)
+  }, [images])
+
   const extrema = useMemo(() => {
     if (zoom === 1 || !canZoom ) {
       return {
@@ -137,36 +167,6 @@ export const PredictionsScatterplot = ({ canZoom }) => {
     }
     return { min, max }
   }, [images, index, zoom])
-
-  // massage the prediction data into a format usable by this Nivo graph component.
-  useEffect(() => {
-    const data = { ...initialFeaturePredictions }
-    images.forEach((image, i) => {
-      features.forEach(feature => {
-        if (image.features[feature]) {
-          data[feature].data.push({ x: i + 1, y: image.features[feature].probability, image })
-        }
-        // create dummy nodes?
-        else { data[feature].data.push({ image }) }
-      })
-    })
-    setPredictions(data)
-  }, [images])
-
-  useEffect(() => {
-    const fetchThreshold = async () => {
-      try {
-        const { data } = await api.getThreshold(selectedFeature)
-        if (!data) {
-          throw new Error('An error occurred while fetching thresholds.')
-        }
-        setThreshold(data.model_threshold)
-      } catch (error) {
-        console.error(error)
-      }
-    }
-    fetchThreshold(selectedFeature)
-  }, [selectedFeature])
 
   return (
     <Row gutter={ 32 }>

--- a/src/components/route-browser/route-predictions/scatterplot.js
+++ b/src/components/route-browser/route-predictions/scatterplot.js
@@ -58,10 +58,18 @@ const Graph = ({ data, min, max, predictionThreshold }) => {
     }
   }
 
+  // only render data points that are within the zoomed viewing window
+  const visibleData = useMemo(() => {
+    if (!data || !data[0]) {
+      return []
+    }
+    return [{ ...data[0], data: data[0].data.filter(d => min <= d.x && d.x <= max) }]
+  }, [data, min, max])
+
   return (
     <div className="predictions-scatterplot__container">
       <ResponsiveScatterPlot
-        data={ data }
+        data={ visibleData }
         height={ 175 }
         margin={{ top: 0, right: 8, bottom: 0, left: 40 }}
         xScale={{ type: 'linear', min: min, max: max }}

--- a/src/components/route-browser/route-predictions/scatterplot.js
+++ b/src/components/route-browser/route-predictions/scatterplot.js
@@ -1,13 +1,14 @@
 import React, { Fragment, useEffect, useMemo, useState } from 'react'
 import { useHistory } from 'react-router-dom'
-import { Card, Col, Row, Select, Space, Typography } from 'antd'
+import { Button, Card, Col, Row, Select, Space, Typography } from 'antd'
+import { ZoomInOutlined as ZoomInIcon, ZoomOutOutlined as ZoomOutIcon } from '@ant-design/icons'
 import { useRouteContext } from '../context'
 import { api } from '../../../api'
 import { ResponsiveScatterPlot } from '@nivo/scatterplot'
 import { GraphTooltip, Legend, ScatterplotPoint } from './'
 import './scatterplot.css'
 
-const { Text } = Typography
+const { Text, Title } = Typography
 
 const features = ['guardrail', 'pole']
 
@@ -47,7 +48,7 @@ const ThresholdLineLayer = props => {
   )
 }
 
-const Graph = ({ data, predictionThreshold }) => {
+const Graph = ({ data, min, max, predictionThreshold }) => {
   const history = useHistory()
   const { currentLocation, images, routeID } = useRouteContext()
   
@@ -63,7 +64,7 @@ const Graph = ({ data, predictionThreshold }) => {
         data={ data }
         height={ 175 }
         margin={{ top: 0, right: 8, bottom: 0, left: 40 }}
-        xScale={{ type: 'linear', min: 1, max: images.length }}
+        xScale={{ type: 'linear', min: min, max: max }}
         yScale={{ type: 'linear', min: -0.05, max: 1.05, stacked: false, reverse: false }}
         yFormat=" >-.2f"
         enableGridX={ true }
@@ -108,12 +109,37 @@ const Graph = ({ data, predictionThreshold }) => {
 }
 
 export const PredictionsScatterplot = ({ key }) => {
-  const { images } = useRouteContext()
+  const { images, index } = useRouteContext()
   const [predictions, setPredictions] = useState([])
   const [selectedFeature, setSelectedFeature] = useState('guardrail')
   const [threshold, setThreshold] = useState()
-
+  const [zoom, setZoom] = useState(1)
   const handleFeatureSelect = value => setSelectedFeature(value)
+  const handleZoomSelect = value => setZoom(value)
+
+  const extrema = useMemo(() => {
+    if (zoom === 1) {
+      return {
+        min: 1,
+        max: images.length,
+      }
+    }
+    const zoomRadius = Math.ceil(images.length / (2 * zoom))
+    let min = Math.max(0, index - zoomRadius)
+    let max = Math.min(images.length, index + zoomRadius)
+    if (min < 1) {
+      min = 1
+      max = 2 * zoomRadius
+    }
+    if (max > images.length) {
+      min -= images.length - 2 * zoomRadius
+      max = images.length
+    }
+    return {
+      min: min,
+      max: max,
+    }
+  }, [index, zoom])
 
   // massage the prediction data into a format usable by this Nivo graph component.
   useEffect(() => {
@@ -148,11 +174,14 @@ export const PredictionsScatterplot = ({ key }) => {
   return (
     <Row gutter={ 32 }>
       <Col xs={ 24 } lg={ 18 }>
-        <Graph data={ [predictions[selectedFeature]] } predictionThreshold={ threshold } />
+        <Graph data={ [predictions[selectedFeature]] } predictionThreshold={ threshold } min={ extrema.min } max={ extrema.max } />
       </Col>
       <Col xs={ 24 } lg={ 6 }>
         <Select value={ selectedFeature } onChange={ handleFeatureSelect } style={{ width: '100%' }}>
           { features.map(feature => <Select.Option key={ `feature-option-${ feature }` } value={ feature }>{ feature }</Select.Option>) }
+        </Select>
+        <Select value={ zoom } onChange={ handleZoomSelect } style={{ width: '100%' }}>
+          { [1, 2, 3, 4, 5].map(level => <Select.Option key={ `zoom-option-${ level }x` } value={ level }>{ `Zoom ${ level }x` }</Select.Option>) }
         </Select>
         <Legend />
       </Col>

--- a/src/components/route-browser/route-predictions/scatterplot.js
+++ b/src/components/route-browser/route-predictions/scatterplot.js
@@ -125,20 +125,17 @@ export const PredictionsScatterplot = ({ canZoom }) => {
       }
     }
     const zoomRadius = Math.ceil(images.length / (2 * zoom))
-    let min = Math.max(0, index - zoomRadius)
-    let max = Math.min(images.length, index + zoomRadius)
+    let min = index - zoomRadius
+    let max = index + zoomRadius
     if (min < 1) {
       min = 1
       max = 2 * zoomRadius
     }
     if (max > images.length) {
-      min -= images.length - 2 * zoomRadius
+      min = images.length - 2 * zoomRadius
       max = images.length
     }
-    return {
-      min: min,
-      max: max,
-    }
+    return { min, max }
   }, [images, index, zoom])
 
   // massage the prediction data into a format usable by this Nivo graph component.
@@ -174,7 +171,7 @@ export const PredictionsScatterplot = ({ canZoom }) => {
   return (
     <Row gutter={ 32 }>
       <Col xs={ 24 } lg={ 18 }>
-        <Graph data={ [predictions[selectedFeature]] } predictionThreshold={ threshold } min={ extrema.min } max={ extrema.max } />
+        <Graph data={ [predictions[selectedFeature]] } predictionThreshold={ threshold } { ...extrema } />
       </Col>
       <Col xs={ 24 } lg={ 6 }>
         <Select value={ selectedFeature } onChange={ handleFeatureSelect } style={{ width: '100%' }}>

--- a/src/views/routes/route-browser.js
+++ b/src/views/routes/route-browser.js
@@ -56,7 +56,7 @@ export const RouteBrowserView = () => {
         <Button type="primary" ghost onClick={ () => history.push(`/routes/${ routeID }/`) } className="route-action-button" icon={ <SummaryIcon /> }>View Route Summary</Button>
       </div>
 
-      <PredictionsScatterplot />
+      <PredictionsScatterplot canZoom={ true } />
       <RouteNavigation />
 
       <br />


### PR DESCRIPTION
the changes in this PR add the ability to zoom in along the horizontal axis of the route predictions scatterplot. the zoom options here are hard-coded as 1x (entire route), 2x, 3x, 4x, and 5x.