### PR TITLE
Feature/persist feature

### DIFF
--- a/src/components/route-browser/route-predictions/scatterplot.js
+++ b/src/components/route-browser/route-predictions/scatterplot.js
@@ -2,8 +2,9 @@ import React, { Fragment, useEffect, useMemo, useState } from 'react'
 import { useHistory } from 'react-router-dom'
 import { Button, Card, Col, Row, Select, Space, Typography } from 'antd'
 import { ZoomInOutlined as ZoomInIcon, ZoomOutOutlined as ZoomOutIcon } from '@ant-design/icons'
-import { useRouteContext } from '../context'
 import { api } from '../../../api'
+import { useLocalStorage } from '../../../hooks'
+import { useRouteContext } from '../context'
 import { ResponsiveScatterPlot } from '@nivo/scatterplot'
 import { GraphTooltip, Legend, ScatterplotPoint } from './'
 import './scatterplot.css'
@@ -120,7 +121,7 @@ const Graph = ({ data, min, max, predictionThreshold }) => {
 export const PredictionsScatterplot = ({ canZoom }) => {
   const { images, index } = useRouteContext()
   const [predictions, setPredictions] = useState([])
-  const [selectedFeature, setSelectedFeature] = useState('guardrail')
+  const [selectedFeature, setSelectedFeature] = useLocalStorage('rhf-annotation-feature', 'guardrail')
   const [threshold, setThreshold] = useState()
   const [zoom, setZoom] = useState(1)
   const handleFeatureSelect = value => setSelectedFeature(value)

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,0 +1,1 @@
+export * from './use-local-storage'

--- a/src/hooks/use-local-storage.js
+++ b/src/hooks/use-local-storage.js
@@ -1,0 +1,36 @@
+import { useState } from 'react'
+
+export const useLocalStorage = (key, initialValue) => {
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState(() => {
+    try {
+      // Get from local storage by key
+      const item = window.localStorage.getItem(key)
+      // Parse stored json or if none return initialValue
+      return item ? JSON.parse(item) : initialValue
+    } catch (error) {
+      // If error also return initialValue
+      console.log(error)
+      return initialValue
+      }
+    })
+
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to localStorage.
+  const setValue = value => {
+    try {
+      // Allow value to be a function so we have same API as useState
+      const valueToStore = value instanceof Function ? value(storedValue) : value
+      // Save state
+      setStoredValue(valueToStore)
+      // Save to local storage
+      window.localStorage.setItem(key, JSON.stringify(valueToStore))
+    } catch (error) {
+      // A more advanced implementation would handle the error case
+      console.log(error)
+    }
+  }
+
+  return [storedValue, setValue]
+}


### PR DESCRIPTION
this PR adds a use-local-storage hook and implements it to make the user's annotation feature selection persist between the prediction errors view and the route browse view.