### PR TITLE
Bugfix/route summary map error

### DIFF
--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -27,13 +27,13 @@ export const Map = ({ height, markers, path, zoom, basemapSelection = true }) =>
       >
         {
           // draw a path if there is one
-          path.length && <Path coordinates={ path } />
+          path.length ? <Path coordinates={ path } /> : <></>
         }
         {
           // draw any markers
-            markers.map(({ key, ...props }, i) => (
-              <Marker key={ `marker-${ i }_-${ props.long },${ props.lat }` } { ...props } />
-            ))
+          markers.map(({ key, ...props }, i) => (
+            <Marker key={ `marker-${ i }_-${ props.long },${ props.lat }` } { ...props } />
+          ))
         }
       </EsriMap>
       {

--- a/src/views/routes/route-summary.js
+++ b/src/views/routes/route-summary.js
@@ -109,7 +109,7 @@ export const RouteSummaryView = () => {
             {
               annotationCounts ? Object.keys(annotationCounts).map(feature => {
                 return (
-                  <Space direction="horizontal" size="large">
+                  <Space direction="horizontal" size="large" key={ `feature-annotation-counts-${ feature }` }>
                     <Statistic
                       title={ <Title level={ 5 }>{ feature[0].toUpperCase() + feature.slice(1) }</Title> }
                       value={ annotationCounts[feature].present + annotationCounts[feature].absent }

--- a/src/views/routes/route-summary.js
+++ b/src/views/routes/route-summary.js
@@ -30,8 +30,8 @@ const initialAnnotationCounts = ['guardrail', 'pole'].reduce((obj, feature) => (
 export const RouteSummaryView = () => {
   const history = useHistory()
   const { routeID, routeLength, images } = useRouteContext()
-  const [startingCoordinates, setStartingCoordinates] = useState({ lat: 0, long: 0 })
-  const [endingCoordinates, setEndingCoordinates] = useState({ lat: 0, long: 0 })
+  const [startingCoordinates, setStartingCoordinates] = useState()
+  const [endingCoordinates, setEndingCoordinates] = useState()
   const [pathCoordinates, setPathCoordinates] = useState([])
   const [annotationCounts, setAnnotationCounts] = useState()
 
@@ -133,7 +133,7 @@ export const RouteSummaryView = () => {
       <Divider orientation="center">Map</Divider>
 
       <Map
-        markers={ [startingCoordinates, endingCoordinates] }
+        markers={ startingCoordinates && endingCoordinates ? [startingCoordinates, endingCoordinates] : [] }
         path={ pathCoordinates }
         height="600px"
         zoom={ 13 }


### PR DESCRIPTION
I believe the issue was that EsriMap is performing a react.Clone of its children, but a null object was being passed as a child if path.length was zero, which caused a problem. Currently fixed by passing an empty fragment if path.length is zero. It may be cleaner to always render the path component and handle the empty coordinates array in there, but I'll leave that you @mbwatson if you want to investigate that.