### PR TITLE
Bugfix/scatterplot multiple points

### DIFF
--- a/src/components/route-browser/route-predictions/scatterplot.js
+++ b/src/components/route-browser/route-predictions/scatterplot.js
@@ -14,7 +14,7 @@ const { Text, Title } = Typography
 
 const features = ['guardrail', 'pole']
 
-const initialFeaturePredictions = features.reduce((obj, feature) => ({ ...obj, [feature]: { id: feature, data: [] } }), {})
+const initializeFeaturePredictions = () => features.reduce((obj, feature) => ({ ...obj, [feature]: { id: feature, data: [] } }), {})
 
 const ThresholdLineLayer = props => {
   const { height, width, data } = props
@@ -157,7 +157,8 @@ export const PredictionsScatterplot = ({ canZoom }) => {
 
   // massage the prediction data into a format usable by this Nivo graph component.
   useEffect(() => {
-    const data = { ...initialFeaturePredictions }
+    const data = initializeFeaturePredictions()
+
     images.forEach((image, i) => {
       features.forEach(feature => {
         if (image.features[feature]) {


### PR DESCRIPTION
The issue was that when initializing data to initialFeaturePredictions, the spread operator was used to create a new object, but that performs a shallow copy, so the internal data array was being reused, and appended to with the points from the new route when a new route was selected. Fixed this by changing initialFeaturePredictions object to initializeFeaturePredictions function that returns a newly created object each time.